### PR TITLE
Fix default export in TS types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -103,7 +103,7 @@ export interface GestureEvents {
   onTouchCancel: React.TouchEventHandler
 }
 
-export function useGesture(
+export default function useGesture(
   handlers: AtLeastOne<GestureHandlers> | CoordinatesHandler,
   config?: Partial<GestureConfig>
 ): (...args: any[]) => Partial<GestureEvents>


### PR DESCRIPTION
Thanks for this great library! I've been using the 5.x branch in a TypeScript project, and was getting an error:
```
TS1192: Module './node_modules/react-use-gesture/types/index' has no default export.
```
I added the `default` keyword and things seem to work.