### PR TITLE
cancelDrag() now cancels drag then does raf->onDragEnd()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ ehthumbs.db
 Desktop.ini
 $RECYCLE.BIN/
 .DS_Store
+.idea

--- a/index.js
+++ b/index.js
@@ -250,7 +250,10 @@ export function useGesture(props, config) {
       handleGesture('onDrag')
     }
 
-    const cancelDrag = event => requestAnimationFrame(() => onDragEnd(event, true))
+    const cancelDrag = event => {
+      updateState({ drag: { canceled: true } })
+      requestAnimationFrame(() => onDragEnd(event, true))
+    }
 
     const onPinchStart = event => {
       if (!configRef.current.enabled || !configRef.current.pinch || event.touches.length !== 2) return


### PR DESCRIPTION
Resolving #52 

NOTE: I did not do something similar to `canclePinch`
- Out of sheer laziness 
- Because I'm not confident this is the approach the maintainers would like to take
- Because this may never be an issue if it only happens when devtools is open and that's difficult to do on mobile (where pinch is possible?)