### PR TITLE
Add onHover to typescript definitions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -77,6 +77,9 @@ export interface GestureHandlers {
   onDrag: CoordinatesHandler
   onDragStart: CoordinatesHandler
   onDragEnd: CoordinatesHandler
+  onHover: CoordinatesHandler
+  onHoverStart: CoordinatesHandler
+  onHoverEnd: CoordinatesHandler
   onMove: CoordinatesHandler
   onMoveStart: CoordinatesHandler
   onMoveEnd: CoordinatesHandler

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -78,8 +78,6 @@ export interface GestureHandlers {
   onDragStart: CoordinatesHandler
   onDragEnd: CoordinatesHandler
   onHover: CoordinatesHandler
-  onHoverStart: CoordinatesHandler
-  onHoverEnd: CoordinatesHandler
   onMove: CoordinatesHandler
   onMoveStart: CoordinatesHandler
   onMoveEnd: CoordinatesHandler


### PR DESCRIPTION
Looks like these were missing from the definitions?