### PR TITLE
Fix TS error about missing Omit type

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,6 +1,6 @@
 import React from 'react'
 import GestureController from './controllers/GestureController'
-import { Handler, GestureHandlersPartial, GestureConfig, Coordinates, Fn, ReactEventHandlers, DistanceAngle } from './types'
+import { Handler, GestureHandlersPartial, GestureConfig, Coordinates, Fn, ReactEventHandlers, DistanceAngle, Omit } from './types'
 import { defaultConfig } from './defaults'
 
 /** API


### PR DESCRIPTION
i'm using typescript 3.4.5., where `Omit` is not included as part of TS,  and i get the following error when using this (awesome!!) lib: 

```
 ../../node_modules/react-use-gesture/dist/hooks.d.ts:16:45 - error TS2304: Cannot find name 'Omit'.
[1] 16 declare type PartialGestureConfig = Partial<Omit<GestureConfig, 'passiveEvents'>>;
```

since this project already defined and exported a type helper for `Omit`, importing it should fix this.