### PR TITLE
Fix typo in README.md code

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ import { useSpring, animated } from 'react-spring'
 import { useDrag } from 'react-use-gesture'
 
 function PullRelease() {
-  const [{ xy }, set] = useSpring(() => ({ x: 0, y: 0 }))
+  const [{ x, y }, set] = useSpring(() => ({ x: 0, y: 0 }))
 
   // 1. Define the gesture
   const bind = useDrag(({ down, movement: [mx, my] }) => set({ x: down ? mx : 0, y: down ? y : 0 }))


### PR DESCRIPTION
It seems like "xy" in the destructured return value of `useSpring()` should be separate variables `x` and `y`.