### PR TITLE
docs: do not use undefined `scale()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ const bind = useDrag(({ active, movement, velocity, direction, memo = pos.getVal
   set({
     pos: addV(movement, memo),
     immediate: active,
-    config: { velocity: scale(direction, velocity), decay: true },
+    config: { velocity: direction.map(d => d * velocity), decay: true },
   })
   return memo
 })


### PR DESCRIPTION
The `scale` method is nowhere to be found, neither on the README or as an exported utility function - it got me confused for a second. I think it's easier to just replace it with a `array#map` function instead