### PR TITLE
add defensive code to releasePointerCapture

### DIFF
--- a/src/recognizers/DragRecognizer.ts
+++ b/src/recognizers/DragRecognizer.ts
@@ -32,7 +32,7 @@ export default class DragRecognizer extends CoordinatesRecognizer<'drag'> {
   private removePointers = () => {
     const { currentTarget, pointerId } = this.state
     // @ts-ignore
-    currentTarget.releasePointerCapture(pointerId)
+    if (currentTarget) currentTarget.releasePointerCapture(pointerId)
   }
 
   private setListeners = () => {


### PR DESCRIPTION
when running tests in my app with [Cypress:click](https://docs.cypress.io/api/commands/click.html#History) I am presented with errors because `currentTarget` is `null`. I assume that it happens because Cypress must be triggering events in a non natural manner.