### PR TITLE
Fix shift -> shiftKey in the docs

### DIFF
--- a/docusaurus/docs/state.mdx
+++ b/docusaurus/docs/state.mdx
@@ -45,7 +45,7 @@ const bind = useXXXX(state => {
     args,        // arguments you passed to bind
     ctrlKey,     // true when control key is pressed
     altKey,      // "      "  alt     "      "
-    shift,       // "      "  shift   "      "
+    shiftKey,    // "      "  shift   "      "
     metaKey,     // "      "  meta    "      "
     dragging,    // is the component currently being dragged
     moving,      // "              "              "  moved


### PR DESCRIPTION
Noticed this was incorrect: `shiftKey` is what works, not `shift`