### PR TITLE
feat: defined sign function for supporting IE

### DIFF
--- a/src/recognizers/DistanceAngleRecognizer.ts
+++ b/src/recognizers/DistanceAngleRecognizer.ts
@@ -1,5 +1,5 @@
 import Recognizer from './Recognizer'
-import { calculateAllKinematics } from '../utils/math'
+import { calculateAllKinematics, sign } from '../utils/math'
 import { Vector2, UseGestureEvent, PartialGestureState, DistanceAngleKey, GestureState } from '../types'
 
 /**
@@ -28,7 +28,7 @@ export default abstract class DistanceAngleRecognizer<T extends DistanceAngleKey
      * read 181deg to ensure continuity. To make that happen, we detect when the jump
      * is supsiciously high (ie > 270deg) and increase the `turns` value
      */
-    const newTurns = Math.abs(delta_a) > 270 ? turns + Math.sign(delta_a) : turns
+    const newTurns = Math.abs(delta_a) > 270 ? turns + sign(delta_a) : turns
 
     // we update the angle difference to its corrected value
 

--- a/src/recognizers/DragRecognizer.ts
+++ b/src/recognizers/DragRecognizer.ts
@@ -4,7 +4,7 @@ import Controller from '../Controller'
 import { UseGestureEvent, Fn, IngKey } from '../types'
 import { noop } from '../utils/utils'
 import { getPointerEventValues, getGenericEventData } from '../utils/event'
-import { calculateDistance } from '../utils/math'
+import { calculateDistance, sign } from '../utils/math'
 
 const TAP_DISTANCE_THRESHOLD = 3
 const SWIPE_MAX_ELAPSED_TIME = 220
@@ -164,8 +164,8 @@ export default class DragRecognizer extends CoordinatesRecognizer<'drag'> {
     const swipe: [number, number] = [0, 0]
 
     if (elapsedTime < SWIPE_MAX_ELAPSED_TIME) {
-      if (ix !== false && Math.abs(vx) > svx && Math.abs(mx) > sx) swipe[0] = Math.sign(vx)
-      if (iy !== false && Math.abs(vy) > svy && Math.abs(my) > sy) swipe[1] = Math.sign(vy)
+      if (ix !== false && Math.abs(vx) > svx && Math.abs(mx) > sx) swipe[0] = sign(vx)
+      if (iy !== false && Math.abs(vy) > svy && Math.abs(my) > sy) swipe[1] = sign(vy)
     }
 
     this.updateGestureState({

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -77,12 +77,15 @@ export function calculateAllKinematics<T extends number[]>(movement: T, delta: T
   }
 }
 
+/**
+ * Because IE doesn't support `Math.sign` function, so we use the polyfill version of the function.
+ * This polyfill function came from
+ * :https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sign#Polyfill
+ * @param x target number
+ */
 export function sign(x: number) {
-  let num = Number(x)
-  if (num === 0 || isNaN(num)) {
-    return num
-  }
-  return num > 0 ? 1 : -1
+  if (Math.sign) return Math.sign(x)
+  return Number(x > 0) - Number(x < 0) || +x
 }
 
 export function getIntentionalDisplacement(movement: number, threshold: number): number | false {

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -77,9 +77,17 @@ export function calculateAllKinematics<T extends number[]>(movement: T, delta: T
   }
 }
 
+export function sign(x: number) {
+  let num = Number(x)
+  if (num === 0 || isNaN(num)) {
+    return num
+  }
+  return num > 0 ? 1 : -1
+}
+
 export function getIntentionalDisplacement(movement: number, threshold: number): number | false {
   const abs = Math.abs(movement)
-  return abs >= threshold ? Math.sign(movement) * threshold : false
+  return abs >= threshold ? sign(movement) * threshold : false
 }
 
 function minMax(value: number, min: number, max: number) {

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -79,7 +79,7 @@ export function calculateAllKinematics<T extends number[]>(movement: T, delta: T
 
 /**
  * Because IE doesn't support `Math.sign` function, so we use the polyfill version of the function.
- * This polyfill function came from
+ * This polyfill function is suggested by Mozilla
  * :https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sign#Polyfill
  * @param x target number
  */


### PR DESCRIPTION
Because IE doesn't support `Math.sign`, I defined polyfill function and applied it to all position where `Math.sign` was used. It performs the same functionality.